### PR TITLE
Add QMK Tap Dance to ESC/Backtick key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Swap left `Alt` and left `GUI` keys. Right `Alt` remains unchanged. (#1, #6)
 - Swap `Esc` and Backtick (`` ` ``) (#3)
+- Add [QMK Tap Dance Feature](https://beta.docs.qmk.fm/using-qmk/software-features/feature_tap_dance) to ESC/Backtick key, so the behavior when hitting the key varies based on the number of times it is hit in rapid succession (#5):
+    - Once: `` ` ``
+    - Twice: `<Esc>`
+    - Three times: `` ``` ``
+    - etc.
 
 ### Added
 - Add default `massdrop/alt` configuration

--- a/keymap.c
+++ b/keymap.c
@@ -38,7 +38,7 @@ qk_tap_dance_action_t tap_dance_actions[] = {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_65_ansi_blocker(
-        KC_GRV,                                                                                                                                \
+        TD(TD_BACKTICK_ESC),                                                                                                                   \
                  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_HOME, \
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP, \

--- a/keymap.c
+++ b/keymap.c
@@ -10,6 +10,10 @@ enum alt_keycodes {
     MD_BOOT,               //Restart into bootloader after hold timeout
 };
 
+enum tapdance_keycodes {
+    TD_BACKTICK_ESC,       //Tap Dance Backtick / Esc
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_65_ansi_blocker(
         KC_GRV,                                                                                                                                \

--- a/keymap.c
+++ b/keymap.c
@@ -31,6 +31,11 @@ void td_backtick_exactly_2_esc(qk_tap_dance_state_t *state, void *user_data) {
     }
 }
 
+// Tap Dance definitions
+qk_tap_dance_action_t tap_dance_actions[] = {
+    [TD_BACKTICK_ESC] = ACTION_TAP_DANCE_FN(td_backtick_exactly_2_esc),
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_65_ansi_blocker(
         KC_GRV,                                                                                                                                \

--- a/keymap.c
+++ b/keymap.c
@@ -14,6 +14,23 @@ enum tapdance_keycodes {
     TD_BACKTICK_ESC,       //Tap Dance Backtick / Esc
 };
 
+/**
+ * When the key was tapped exactly 2 times, KC_ESC
+ * otherwise, KC_GRV the appropriate number of times.
+ */
+void td_backtick_exactly_2_esc(qk_tap_dance_state_t *state, void *user_data) {
+    int i;
+
+    if (state->count == 2) {
+        tap_code(KC_ESC);
+        return;
+    }
+
+    for (i=0; i<state->count; i++) {
+        tap_code(KC_GRV);
+    }
+}
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_65_ansi_blocker(
         KC_GRV,                                                                                                                                \

--- a/keymap.c
+++ b/keymap.c
@@ -12,7 +12,8 @@ enum alt_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT_65_ansi_blocker(
-        KC_GRV,  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \
+        KC_GRV,                                                                                                                                \
+                 KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC, KC_DEL,  \
         KC_TAB,  KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS, KC_HOME, \
         KC_CAPS, KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT,          KC_ENT,  KC_PGUP, \
         KC_LSFT, KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,          KC_UP,   KC_PGDN, \

--- a/rules.mk
+++ b/rules.mk
@@ -1,0 +1,1 @@
+TAP_DANCE_ENABLE = yes


### PR DESCRIPTION
Add [QMK Tap Dance Feature](https://beta.docs.qmk.fm/using-qmk/software-features/feature_tap_dance) to ESC/Backtick key, so the behavior when hitting the key varies based on the number of times it is hit in rapid succession:

- Once: `` ` ``
- Twice: `<Esc>`
- Three times: `` ``` ``
- Four times: `` ```` ``
- etc.

Resolves #5 